### PR TITLE
Release6

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -78,7 +78,21 @@
  -    >.venv/bin/python initcloud_web/manage.py runserver 0.0.0.0:8081
  -
  -
- -### 12. Celery worker
+
+ -### 12. staff
+      cd /var/www/initcloud_web
+ -     .venv/bin/python initcloud_web/manage.py create_audit_user_permission
+ -     .venv/bin/python initcloud_web/manage.py create_system_user_permission
+ -     .venv/bin/python initcloud_web/manage.py create_safety_user_permission
+
+ -    chmod 777 /etc/nova/policy.json
+ -    chmod 777 /etc/cinder/policy.json
+ -    chmod 777 /etc/neutron/policy.json
+
+ -    source /root/keystone_admin
+ -    openstack project create test
+
+ -### 13. Celery worker
  -
  -    >rabbitmqctl add_user initcloud_web password
  -    >rabbitmqctl add_vhost initcloud
@@ -100,13 +114,13 @@
  -    >chmod +x /etc/init.d/celerybeat 
  -    > /etc/init.d/celerybeat restart
  -    > /etc/init.d/celerybeat status
- -### 13 run_celery with auto start
+ -### 14 run_celery with auto start
  -
       >vim /etc/rc.d/rc.local
       su - initcloud -c "cd /var/www/initcloud_web/initcloud_web/;../.venv/bin/celery multi restart initcloud_worker -A cloud --pidfile=/var/log/initcloud/celery_%n.pid --logfile=/var/log/initcloud/celery_%n.log &"
       > chmod +x /etc/rc.d/rc.local
 
-  -## 14 deploy on apache (nginx in beta3)
+  -## 15 deploy on apache (nginx in beta3)
 
       > add Listen port in apache
       > vim /etc/httpd/conf/ports.conf
@@ -115,12 +129,12 @@
       > modify 16-initcloud.conf,like ServerName,ServerAlias
       > systemctl restart httpd.service
 
-  -## 15 check
+  -## 16 check
 
       > browser test.
 
-  -## 16 reboot
+  -## 17 reboot
 
-  -## 17 trouble shooting
+  -## 18 trouble shooting
 
    

--- a/initcloud_web/biz/instance/migrations/0004_instance_policy.py
+++ b/initcloud_web/biz/instance/migrations/0004_instance_policy.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0003_auto_20160606_2118'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='instance',
+            name='policy',
+            field=models.IntegerField(default=0, verbose_name='Policy'),
+            preserve_default=True,
+        ),
+    ]

--- a/initcloud_web/biz/instance/models.py
+++ b/initcloud_web/biz/instance/models.py
@@ -34,6 +34,7 @@ class Instance(models.Model):
     create_date = models.DateTimeField(_("Create Date"), auto_now_add=True)
     terminate_date = models.DateTimeField(_("Terminate Date"), auto_now_add=True)
     cpu = models.IntegerField(_("Cpu Cores"))
+    policy = models.IntegerField(_("Policy"), null=False, default=0)
     memory = models.IntegerField(_("Memory"))
     sys_disk = models.FloatField(_("System Disk"), null=False, blank=True)
     

--- a/initcloud_web/biz/instance/views.py
+++ b/initcloud_web/biz/instance/views.py
@@ -385,7 +385,6 @@ def vdi_view(request):
         LOG.info("******")
         novaAdmin = get_nova_admin(request)
         LOG.info("******")
-        LOG.info("uuid is" + str(uuid))
         if not q.uuid:
             continue
         server = novaAdmin.servers.get(q.uuid)
@@ -394,6 +393,9 @@ def vdi_view(request):
         LOG.info("******")
         server_host = server_dict['OS-EXT-SRV-ATTR:host']
         server_status = server_dict['status']
+        LOG.info("******* server_status is *******" + str(server_status))
+        if server_status == "ERROR":
+            continue
         host_ip = settings.COMPUTE_HOSTS[server_host]
         LOG.info("host ip is" + str(host_ip))
         cmd="virsh -c qemu+tcp://" + host_ip + "/system vncdisplay " + q.uuid
@@ -406,14 +408,14 @@ def vdi_view(request):
         LOG.info("host_ip=" + host_ip)
         LOG.info("port=" + str(port))
         if "error" in str(port):
-            json_value[q.id] = {"vm_uuid": q.uuid, "vm_private_ip": q.private_ip, "vm_public_ip": q.public_ip, "vm_host": host_ip, "vm_status": server_status, "policy_device": 1, "vnc_port": "no port", "vm_internalid": q.id, "vm_name": q.name}
+            json_value[q.id] = {"vm_uuid": q.uuid, "vm_private_ip": q.private_ip, "vm_public_ip": q.public_ip, "vm_host": host_ip, "vm_status": server_status, "policy_device": q.policy, "vnc_port": "no port", "vm_internalid": q.id, "vm_name": q.name}
             continue
         split_port = port.split(":")
         port_1 = split_port[1]
         port_2 = port_1.split("\\")
         port_3 = port_2[0]
         vnc_port = 5900 + int(port_3)
-        json_value[q.id] = {"vm_uuid": q.uuid, "vm_private_ip": q.private_ip, "vm_public_ip": q.public_ip, "vm_host": host_ip, "vm_status": server_status, "policy_device": 1, "vnc_port": vnc_port, "vm_internalid": q.id, "vm_name": q.name}
+        json_value[q.id] = {"vm_uuid": q.uuid, "vm_private_ip": q.private_ip, "vm_public_ip": q.public_ip, "vm_host": host_ip, "vm_status": server_status, "policy_device": q.policy, "vnc_port": vnc_port, "vm_internalid": q.id, "vm_name": q.name}
 
     return Response(json_value)
 

--- a/initcloud_web/biz/management/commands/init_flavor.py
+++ b/initcloud_web/biz/management/commands/init_flavor.py
@@ -18,6 +18,6 @@ class Command(BaseCommand):
             }
 
         for name, values in default_inst_types.iteritems():
-            f = Flavor(name=name, memory=values["mem"], cpu=values["vcpus"], price=0)
+            f = Flavor(name=name, memory=values["mem"], cpu=values["vcpus"], price=0, flavorid=values["flavid"])
             f.save()
 

--- a/initcloud_web/biz/urls.py
+++ b/initcloud_web/biz/urls.py
@@ -70,6 +70,8 @@ urlpatterns += [
     url(r'^instances/$', instance_view.InstanceList.as_view()),
     url(r'^instancemanage/$', instancemanage_view.InstancemanageList.as_view()),
     url(r'^instancemanage/devicepolicy/$', instancemanage_view.InstancemanageDevicePolicy.as_view()),
+    url(r'^instancemanage/devicepolicy/update/$', instancemanage_view.devicepolicyupdate),
+    url(r'^instancemanage/devicepolicy/undo/$', instancemanage_view.devicepolicyundo),
     url(r'^instances/vdi/$', instance_view.vdi_view),
     url(r'^instances/(?P<pk>[0-9]+)/$', instance_view.InstanceDetail.as_view()),
     url(r'^instances/details/(?P<pk>[0-9]+)/$', instance_view.instance_detail_view),

--- a/initcloud_web/render/static/cloud/layout/sidebar.html
+++ b/initcloud_web/render/static/cloud/layout/sidebar.html
@@ -37,14 +37,6 @@
                 </span>
             </a>
         </li>
-        <li data-ng-if="site_config.BACKUP_ENABLED">
-            <a href="#/backup/">
-                <i class="fa fa-archive"></i>
-                <span class="title">
-                    {[{ 'sidebar.backup' | i18next }]}
-                </span>
-            </a>
-        </li>
         <li id="image">
             <a href="#/image/">
                 <i class="fa  fa-circle-o-notch"></i>

--- a/initcloud_web/render/static/locales/cn/translation.json
+++ b/initcloud_web/render/static/locales/cn/translation.json
@@ -870,6 +870,11 @@
       "cpu": "cpu",
       "memory": "内存",
       "public_ip": "公网ip",
+      "policy": "usb重定向权限",
+      "update_instancemanage_title": "分配权限",
+      "edit": "分配权限",
+      "delete": "取消权限",
+      "confirm_delete": "确定取消吗",
       "assignrole": "分配权限"
 
 }    

--- a/initcloud_web/render/static/management/2
+++ b/initcloud_web/render/static/management/2
@@ -141,27 +141,4 @@ def devicepolicyupdate(request):
         role_list = role_str.split(",")
     LOG.info("********** role_list is **********" + str(role_list))
     LOG.info("********** instance_id  is **********" + str(instance_id))
-    if "usb" in role_list:
-        for role in role_list:
-            LOG.info("*** role is ****" + str(role))
-
-
-            instance = Instance.objects.get(pk=instance_id)
-            instance.policy = 1 
-            instance.save()
-    return Response({"success": True, "msg": _(
-           'Sucess.')})
-
-@require_POST
-def devicepolicyundo(request):
-    LOG.info("*** request.data is ***"  + str(request.data))
-    instance_id = None
-    for key, value in request.data.items():
-        instance_id = value
-    LOG.info("********** instance_id  is **********" + str(instance_id))
-    instance = Instance.objects.get(pk=instance_id)
-    instance.policy = 0 
-    instance.save()
-    return Response({"success": True, "msg": _(
-           'Sucess.')})
-
+    return False

--- a/initcloud_web/render/static/management/views/instancemanage.html
+++ b/initcloud_web/render/static/management/views/instancemanage.html
@@ -6,9 +6,6 @@
                     <a class="btn btn-icon-only btn-default" href="#" ng-click="instancemanage_table.reload();">
                         <i class="fa fa-refresh"></i>
                     </a>
-                    <a class="btn btn-primary" href="#" ng-click="openNewInstancemanageModal()">
-                        <i class="fa fa-plus"></i>{[{ 'action.add' | i18next }]}
-                    </a>
                     <!--
                     <a class="btn btn-info" href="#" ng-click="openBroadcastModal()">
                         <i class="fa  fa-bullhorn"></i> {[{ 'notification.broadcast' | i18next }]}
@@ -34,21 +31,18 @@
                                 <td data-title="'instancemanage.name' | i18next">
                                     <span> {[{ instancemanage.name }]} </span>
                                 </td>
-                                <td data-title="'instancemanage.cpu' | i18next">
-                                    <span> {[{ instancemanage.cpu }]} </span>
-                                </td>
-                                <td data-title="'instancemanage.memory' | i18next">
-                                    <span> {[{ instancemanage.memory }]} </span>
-                                </td>
                                 <td data-title="'instancemanage.public_ip' | i18next">
                                     <span> {[{ instancemanage.public_ip }]} </span>
+                                </td>
+                                <td data-title="'instancemanage.policy' | i18next">
+                                    <span> {[{ instancemanage.policy }]} </span>
                                 </td>
                                 <td data-title="'actions' | i18next">
                                     <div class="btn-group">
                                         <button class="btn btn-default"
                                                 type="button" ng-click="edit(instancemanage)">
                                             <i class="fa fa-edit"></i>
-                                            {[{ 'action.edit' | i18next }]}
+                                            {[{ 'instancemanage.edit' | i18next }]}
                                         </button>
                                         <button data-toggle="dropdown" class="btn btn-default dropdown-toggle"
                                                 type="button" aria-expanded="false">
@@ -58,12 +52,7 @@
                                             <li>
                                                 <a href="javascript:void(0);"  ng-click="delete(instancemanage)">
                                                     <i class="fa fa-trash"></i>
-                                                    {[{ 'action.delete' | i18next }]} </a>
-                                            </li>
-                                            <li>
-                                                <a href="javascript:void(0);"  ng-click="assignrole(instancemanage)">
-                                                    <i class="fa fa-trash"></i>
-                                                    {[{ 'instancemanage.assignrole' | i18next }]} </a>
+                                                    {[{ 'instancemanage.delete' | i18next }]} </a>
                                             </li>
                                         </ul>
                                     </div>
@@ -319,7 +308,7 @@
        <div class="modal-title"> {[{ 'instancemanage.new_instancemanage' | i18next }]}</div>
     </div>
     <div class="modal-body">
-        <form id="insancemanageForm" instancemanage="form" class="form-horizontal form-bordered">
+        <form id="instancemanageForm" instancemanage="form" class="form-horizontal form-bordered">
             <div class="form-group">
                 <label class="control-label col-md-3">
                     {[{ 'instancemanage.name' | i18next }]}
@@ -350,16 +339,17 @@
 </script>
 <!-- END TEMPLATE DETAIL-->
 
-<!-- BEGIN ASSIGNROLE UPDATE -->
-<script type="text/ng-template" id="assignrole.html">
+<!-- BEGIN TEMPLATE UPDATE -->
+<script type="text/ng-template" id="update.html">
     <div class="modal-header">
        <div id="updateTitle" class="modal-title"> {[{ 'instancemanage.update_instancemanage_title' | i18next }]}</div>
     </div>
     <div class="modal-body">
-        <form id="instancemanageForm" instancemanage="form" class="form-horizontal form-bordered">
+       <table>
+        <form id="InstancemanageForm" instancemanage="form" class="form-horizontal form-bordered">
             <input type="hidden"  name="id" data-ng-model="instancemanage.id">
             <div class="form-group">
-                <tr data-ng-repeat="role in devicepolicy">
+                <tr data-ng-repeat="role in roles">
                 <td width="30" header="'checkbox-header.html'">
                     <input type="checkbox" data-ng-model="role.checked"/>
                 </td>
@@ -370,39 +360,7 @@
             </div>
             <div class="clear"></div>
         </form>
-    </div>
-    <div class="modal-footer">
-        <a href="javascript:void(0);" class="btn btn-default" data-ng-click="cancel()">
-            {[{ 'cancel' | i18next }]}
-        </a>
-        <a class="btn btn-primary"
-           data-ng-click="submit(instancemanage)"
-           data-nap-after-click> {[{ 'submit' | i18next }]}</a>
-    </div>
-</script>
-<!-- END ASSIGNROLE UPDATE -->
-
-
-<!-- BEGIN TEMPLATE UPDATE -->
-<script type="text/ng-template" id="update.html">
-    <div class="modal-header">
-       <div id="updateTitle" class="modal-title"> {[{ 'instancemanage.update_instancemanage_title' | i18next }]}</div>
-    </div>
-    <div class="modal-body">
-        <form id="InstancemanageForm" instancemanage="form" class="form-horizontal form-bordered">
-            <input type="hidden"  name="id" data-ng-model="instancemanage.id">
-            <div class="form-group">
-                <label class="col-md-3 control-label" for="name">
-                    {[{ 'instancemanage.name' | i18next }]}
-                    <span class="required" aria-required="true"> * </span>
-                </label>
-                <div class="col-md-5">
-                    <input id="instancemanage_name" name="instancemanage_name"  data-ng-model="instancemanage.instancemanagename"  maxlength="64"
-                           class="form-control input-medium required">
-                </div>
-            </div>
-            <div class="clear"></div>
-        </form>
+       </table>
     </div>
     <div class="modal-footer">
         <a href="javascript:void(0);" class="btn btn-default" data-ng-click="cancel()">


### PR DESCRIPTION
Release Notes:

```
 1.管理段添加了虚拟机管理（指定外设权限）

  2.修复了init_flavor命令失败的问题

        原因是缺少了flavorid指定

 3.vdi接口

        当某个实例创建失败时，vdi接口能够正常返回。

 4.管理段创建用户时，给出租户选择

 5.deploy.sh更新
```

关于数据的配置：
配置文件在：/var/www/initcloud_web/initcloud_web/initcloud_web/local/local_settings.py /var/www/initcloud_web/initcloud_web/initcloud_web/local/default_settings.py

NAME 无须改动
PASSWORD 要和deploy.sh中的一致，默认不需改动
HOST  改成mysql所在的ip，本机无须改动。
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.mysql',
        'NAME': "cloud_web",
        'USER': "cloud_web",
        'PASSWORD': "password",
        'HOST': "127.0.0.1",
        'PORT': "3306",
        'TEST_CHARSET': 'utf8',
        'OPTIONS': {
            'init_command': 'SET storage_engine=INNODB',
        }
    }
}

关于celery中rabbit(broker的配置)，配置文件和数据库相同（见上）

BROKER_URL = "amqp://initcloud_web:password@127.0.0.1:5672/initcloud"
