### PR TITLE
Release9

### DIFF
--- a/initcloud_web/initcloud_web/settings.py
+++ b/initcloud_web/initcloud_web/settings.py
@@ -275,3 +275,4 @@ RESULT = [{"meter_name": "cpu_util"},{'meter_name':"memory.usage"},{"meter_name"
 COMPUTE_HOSTS = {'libertyall': "192.168.223.108"}
 
 DEVICEPOLICY = [{"name":"usb"}]
+VLAN_ENABLED = False


### PR DESCRIPTION
添加了对vlan的支持。

```
管理员在原生horizon中创建vlan网络之后，用户在创建虚拟机的时候，会自动匹配已经存在的vlan网络，不会创建网络。


 vlan网络调整：

      1.判断当前租户有没有网络。如果没有网络的话，

      2.判断当前租户有没有网络。如果有网络的话，直接使用。并将网络信息录入系统。
```

优化了vxlan的支持。

```
 vxlan网络调整：


      判断有没有网络，以系统数据库中存的信息为准，即查询network。

      1.判断当前租户有没有网络.如果有网络的话，分别检查有没有子网、路由，没有则分别创建。

      2.判断当前租户有没有网络。如果没有网络的话，分别创建子网、路由。

      3.判断当前租户有没有网络。如果有网络的话，直接使用。



路由：

      1.创建路由，使用名字即可创建。

      2.创建完路之后，需要绑定外部网关,与外部网络相连（这里的外部指的是external_network.）。同时，还需要增加接口，与内网相连。
```

目前，我们限制同一个租户只存在一个网络；同时，外网个数也是一个。考虑在用户端隐藏网络功能，这也是目前各大厂商通用的做法。

部署手册：

```
请先备份，然后对比相应的文件，进行更新。

1.instance

cp /var/www/initcloud_web/initcloud_web/biz/instance/views.py /var/www/initcloud_web/initcloud_web/biz/instance/views.py.bak

请将附件中的views.py拷贝至/var/www/initcloud_web/initcloud_web/biz/instance/views.py 完成更新

2.celery task

cp /var/www/initcloud_web/initcloud_web/cloud/network_task.py /var/www/initcloud_web/initcloud_web/cloud/network_task.py.bak

cp /var/www/initcloud_web/initcloud_web/cloud/instance_task.py /var/www/initcloud_web/initcloud_web/cloud/instance_task.py.bak

请将附件中的instance_task.py network_task.py拷贝至/var/www/initcloud_web/initcloud_web/cloud/


3.settings

vim /var/www/initcloud_web/initcloud_web/initcloud_web/settings.py

#added 

VLAN_ENABLED = False



4.restart service

docs/restart_all_service

5.tests
```
